### PR TITLE
Add 'Back to the Blog' post

### DIFF
--- a/_posts/2026-07-18-back-to-the-blog.md
+++ b/_posts/2026-07-18-back-to-the-blog.md
@@ -1,0 +1,45 @@
+---
+layout: post
+title: "Back to the Blog"
+date: 2026-07-18
+permalink: back-to-the-blog
+categories: [blog]
+tags: [blog, writing]
+description: "A short note on returning to writing and making space for small, steady posts."
+excerpt_separator: <!--more-->
+---
+
+It has been a while since the last post, and that is probably the best reason to write this one.
+
+<!--more-->
+
+There is a funny thing about having a blog. The longer you stay away from it, the more every new idea starts asking for permission to be big, polished, and worth the silence that came before it.
+
+That is a trap.
+
+A blog does not always need a grand comeback. Sometimes it only needs a small post that says: we are still here, we still like learning, and we still think writing is one of the best ways to understand what we know.
+
+## The small-post strategy
+
+I want this space to feel easier to return to. That means making room for posts that are:
+
+- short notes about something I learned
+- rough explanations of a feature I want to understand better
+- conference or meetup reflections
+- tiny experiments that may later become bigger articles
+
+Not every post has to be a complete guide. Some posts can simply be breadcrumbs.
+
+## Why write it down?
+
+Because the act of writing turns a vague thought into something that can be inspected. It reveals the missing pieces. It shows where the explanation becomes hand-wavy. It also leaves a trail for future me, who will almost certainly forget the exact detail I was so confident I would remember.
+
+This has always been the good part of blogging: it is public enough to make you care, but personal enough to let you keep your own voice.
+
+## What comes next
+
+The plan is simple: write more often, keep the posts useful, and not wait for perfect timing.
+
+There will still be Java here. Probably plenty of it. But there may also be notes about tools, architecture, developer experience, and the human side of building software.
+
+Small posts count too.


### PR DESCRIPTION
### Motivation
- Provide a short return-to-writing post to lower the barrier for smaller, more frequent entries and to signal the blog is active again.
- Encourage a mix of short notes, rough explanations, meetup reflections, and small experiments instead of waiting for polished long-form posts.

### Description
- Add new Jekyll post `_posts/2026-07-18-back-to-the-blog.md` with front matter (`layout`, `title`, `date`, `permalink`, `categories`, `tags`, `description`, `excerpt_separator`) and the post body describing the "small-post" strategy.
- Content-only change; committed the new file and created a PR titled "Add blog return post".

### Testing
- Ran `bundle exec jekyll build` but the local `jekyll` executable was missing so the build could not run.
- Attempted `bundle install --path vendor/bundle && JEKYLL_ENV=production bundle exec jekyll build` but dependency resolution failed due to a RubyGems `403 Forbidden` error while fetching gems.
- Git operations (`git add` / `git commit`) completed successfully and the new post file is present in the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b67f64ad8832fa86cfdf8b243097f)