### PR TITLE
Add quoted X post

### DIFF
--- a/_posts/2026-07-18-quoted-from-x.md
+++ b/_posts/2026-07-18-quoted-from-x.md
@@ -5,18 +5,14 @@ date: 2026-07-18 11:46:06 +0000
 permalink: quoted-from-x
 categories: [notes]
 tags: [quote, x]
-description: "A short note quoting a thought I shared on X."
 excerpt_separator: <!--more-->
 ---
 
-I shared a short thought on X today and wanted to keep it here, too.
-
-<!--more-->
-
 <blockquote class="twitter-tweet">
-  <p lang="en" dir="ltr">Quoted from my post on X.</p>
-  <a href="https://x.com/albihasani94/status/2078446208201134322">July 18, 2026</a>
+  <a href="https://x.com/albihasani94/status/2078446208201134322"></a>
 </blockquote>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
-If the embed does not load, the original post is available on [X](https://x.com/albihasani94/status/2078446208201134322){:target="_blank"}.
+<!--more-->
+
+[Original post](https://x.com/albihasani94/status/2078446208201134322){:target="_blank"}

--- a/_posts/2026-07-18-quoted-from-x.md
+++ b/_posts/2026-07-18-quoted-from-x.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Quoted from X"
+date: 2026-07-18 11:46:06 +0000
+permalink: quoted-from-x
+categories: [notes]
+tags: [quote, x]
+description: "A short note quoting a thought I shared on X."
+excerpt_separator: <!--more-->
+---
+
+I shared a short thought on X today and wanted to keep it here, too.
+
+<!--more-->
+
+<blockquote class="twitter-tweet">
+  <p lang="en" dir="ltr">Quoted from my post on X.</p>
+  <a href="https://x.com/albihasani94/status/2078446208201134322">July 18, 2026</a>
+</blockquote>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+If the embed does not load, the original post is available on [X](https://x.com/albihasani94/status/2078446208201134322){:target="_blank"}.


### PR DESCRIPTION
### Motivation
- Keep a record of a short public thought by adding a Jekyll post that embeds and links to the referenced X status.

### Description
- Add a new post file `_posts/2026-07-18-quoted-from-x.md` with front matter (title, date, permalink, categories, tags, description, and `excerpt_separator`) and content that embeds the X status and provides a fallback link.
- The post date was derived from the X snowflake timestamp and set to `2026-07-18 11:46:06 +0000` for accurate chronology.

### Testing
- `JEKYLL_ENV=production bundle exec jekyll build` failed because the `jekyll` executable was not available in the environment.
- `bundle install --path vendor/bundle && JEKYLL_ENV=production bundle exec jekyll build` failed because RubyGems returned `403 Forbidden` while fetching dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b69d08cc4832f88d93eed32ce69b2)